### PR TITLE
limit tracer.FileRepository filename length, fix #9

### DIFF
--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -4,6 +4,7 @@ import os
 import fnmatch
 import time
 import re
+import binascii
 
 from frida.core import ModuleFunction
 
@@ -363,10 +364,10 @@ class FileRepository(Repository):
 
         if isinstance(function, ModuleFunction):
             module_dir = os.path.join(self._repo_dir, to_filename(function.module.name))
-            module_handler_file = os.path.join(module_dir, to_filename(function.name) + ".js")
+            module_handler_file = os.path.join(module_dir, to_handler_filename(function.name))
             handler_files_to_try.append(module_handler_file)
 
-        any_module_handler_file = os.path.join(self._repo_dir, to_filename(function.name) + ".js")
+        any_module_handler_file = os.path.join(self._repo_dir, to_handler_filename(function.name))
         handler_files_to_try.append(any_module_handler_file)
 
         for handler_file in handler_files_to_try:
@@ -504,6 +505,10 @@ def to_filename(name):
             result += "_"
     return result
 
+def to_handler_filename(name):
+    full_filename = to_filename(name)
+    crc = binascii.crc32(full_filename.encode())
+    return full_filename[0:32] + "_%08x.js" % crc
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fix issue #9 - https://github.com/frida/frida-python/issues/9

This limits the handler filename to 42 characters.
Function name (truncated to 32) + "_" (1) + CRC32 (8) + ".js" (3)

I could have checked the PATH again Windows path limit (260) and truncating dynamically based on the actual path length.
But that's a bad idea because the full path may change (ie parent directory is renamed, moved, zip/unzipped), and then the Frida wouldn't be able to find handlers with long names again.
Arguably the simplest & more efficient solution is truncating all to 32 characters, and adding a CRC32 to makes sure we avoid collision.
Of course, the truncating is applied regardless of the actual platform (Windows vs Mac vs Linux) so that things still works when copying handlers on another machine.

Pro:
- Fixes issue #9 on Windows
- Shorter filenames
- Prevent collision thanks to CRC32, even if the function name is truncated

Cons:
- Long function name doesn't appear in full in the filenames
