### PR TITLE
Prevent detecting void as an argument in manpages

### DIFF
--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -320,6 +320,8 @@ class Repository(object):
                 decl = match.group(1)
                 for argm in re.finditer(r"([^* ]*)\s*(,|\))", decl):
                     arg = argm.group(1)
+                    if arg == 'void':
+                        continue
                     if arg == '...':
                         args += '+ ", ..."'
                         varargs = True


### PR DESCRIPTION
Example: `man 2 getuid`