### PR TITLE
Fix colorama/readline collision

### DIFF
--- a/src/frida/__init__.py
+++ b/src/frida/__init__.py
@@ -70,15 +70,15 @@ def get_device_manager():
             print("")
             print("***")
             if str(ex).startswith("No module named "):
-                print(Back.RED + Fore.WHITE + Style.BRIGHT + "Frida native extension not found")
-                print(Fore.WHITE + Style.BRIGHT + "Please check your PYTHONPATH.")
+                print(Back.RED + Fore.WHITE + Style.BRIGHT + "Frida native extension not found" + Style.RESET_ALL)
+                print(Fore.WHITE + Style.BRIGHT + "Please check your PYTHONPATH." + Style.RESET_ALL)
             else:
-                print(Back.RED + Fore.WHITE + Style.BRIGHT + "Failed to load the Frida native extension: %s" % ex)
+                print(Back.RED + Fore.WHITE + Style.BRIGHT + "Failed to load the Frida native extension: %s" % ex + Style.RESET_ALL)
                 if sys.version_info[0] == 2:
                     current_python_version = "%d.%d" % sys.version_info[:2]
                 else:
                     current_python_version = "%d.x" % sys.version_info[0]
-                print(Fore.WHITE + Style.BRIGHT + "Please ensure that the extension was compiled for Python " + current_python_version + ".")
+                print(Fore.WHITE + Style.BRIGHT + "Please ensure that the extension was compiled for Python " + current_python_version + "." + Style.RESET_ALL)
             print("***")
             print("")
             raise ex

--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -22,7 +22,7 @@ def await_enter():
 
 class ConsoleApplication(object):
     def __init__(self, run_until_return=await_enter):
-        colorama.init(autoreset=True)
+        colorama.init()
 
         parser = OptionParser(usage=self._usage())
         parser.add_option("-U", "--usb", help="connect to USB device",

--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -171,7 +171,7 @@ class ConsoleApplication(object):
             cursor_position = "\033[A"
         else:
             cursor_position = ""
-        print("%-80s" % (cursor_position + Style.BRIGHT + message,))
+        print("%-80s" % (cursor_position + Style.BRIGHT + message + Style.RESET_ALL,))
         self._status_updated = True
 
 def find_device(type):

--- a/src/frida/repl.py
+++ b/src/frida/repl.py
@@ -133,7 +133,7 @@ def main():
                                 if stanza['name'] == '+result':
                                     output = json.dumps(value, sort_keys=True, indent=4, separators=(",", ": "))
                                 else:
-                                    output = Fore.RED + Style.BRIGHT + value
+                                    output = Fore.RED + Style.BRIGHT + value + Style.RESET_ALL
                                 sys.stdout.write(output + "\n")
                                 sys.stdout.flush()
                         self._idle.set()


### PR DESCRIPTION
Using autoreset=True in colorama's init function, causes it to wrap
stdin.
This is problematic because readline also messes with stdin, and
causes readline to stop working.

The solution is to simply not use autoreset=True, and then (at least
on non-windows platforms) stdin will not be wrapped

To see the issue - run frida-repl with and without the patch. Without
the patch the arrow keys won't work and will spit control codes, with
the patch everything will work as expected