### PR TITLE
Gracefully handling unicode errors

### DIFF
--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -437,8 +437,8 @@ class Repository(object):
             varargs = False
             try:
                 with open(os.devnull, 'w') as devnull:
-                    output = subprocess.check_output(["man", "-P", "col -b", "2", function.name], stderr=devnull)
-                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}" + function.name + r"\(.*\n(^.+$\n)*)(?:.|\n)*^DESCRIPTION", output.decode(errors="replace"), re.MULTILINE)
+                    output = subprocess.check_output(["man", "-E", "UTF-8", "-P", "col -b", "2", function.name], stderr=devnull)
+                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}" + function.name + r"\(.*\n(^.+$\n)*)(?:.|\n)*^DESCRIPTION", output.decode("UTF-8",errors="replace"), re.MULTILINE)
                 if match:
                     decl = match.group(1)
                     for argm in re.finditer(r"([^* ]*)\s*(,|\))", decl):

--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -438,7 +438,7 @@ class Repository(object):
             try:
                 with open(os.devnull, 'w') as devnull:
                     output = subprocess.check_output(["man", "-P", "col -b", "2", function.name], stderr=devnull)
-                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}" + function.name + r"\(.*\n(^.+$\n)*)(?:.|\n)*^DESCRIPTION", output.decode(), re.MULTILINE)
+                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}" + function.name + r"\(.*\n(^.+$\n)*)(?:.|\n)*^DESCRIPTION", output.decode(errors="replace"), re.MULTILINE)
                 if match:
                     decl = match.group(1)
                     for argm in re.finditer(r"([^* ]*)\s*(,|\))", decl):

--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -6,6 +6,7 @@ import time
 import re
 import binascii
 import subprocess
+import platform 
 
 from frida.core import ModuleFunction, ObjCMethod
 
@@ -437,7 +438,11 @@ class Repository(object):
             varargs = False
             try:
                 with open(os.devnull, 'w') as devnull:
-                    output = subprocess.check_output(["man", "-E", "UTF-8", "-P", "col -b", "2", function.name], stderr=devnull)
+                    output_argv=["man"]
+                    if platform.system() != "Darwin":
+                        output_argv.extend(["-E","UTF-8"])
+                    output_argv.extend(["-P", "col -b", "2", function.name])
+                    output = subprocess.check_output(output_argv, stderr=devnull)
                 match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}" + function.name + r"\(.*\n(^.+$\n)*)(?:.|\n)*^DESCRIPTION", output.decode("UTF-8",errors="replace"), re.MULTILINE)
                 if match:
                     decl = match.group(1)

--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import os
-import fnmatch
-import time
-import re
 import binascii
-import subprocess
+import fnmatch
+import os
 import platform 
+import re
+import subprocess
+import time
 
 from frida.core import ModuleFunction, ObjCMethod
 
@@ -438,12 +438,12 @@ class Repository(object):
             varargs = False
             try:
                 with open(os.devnull, 'w') as devnull:
-                    output_argv=["man"]
+                    man_argv = ["man"]
                     if platform.system() != "Darwin":
-                        output_argv.extend(["-E","UTF-8"])
-                    output_argv.extend(["-P", "col -b", "2", function.name])
-                    output = subprocess.check_output(output_argv, stderr=devnull)
-                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}" + function.name + r"\(.*\n(^.+$\n)*)(?:.|\n)*^DESCRIPTION", output.decode("UTF-8",errors="replace"), re.MULTILINE)
+                        man_argv.extend(["-E", "UTF-8"])
+                    man_argv.extend(["-P", "col -b", "2", function.name])
+                    output = subprocess.check_output(man_argv, stderr=devnull)
+                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}" + function.name + r"\(.*\n(^.+$\n)*)(?:.|\n)*^DESCRIPTION", output.decode('UTF-8', errors='replace'), re.MULTILINE)
                 if match:
                     decl = match.group(1)
                     for argm in re.finditer(r"([^* ]*)\s*(,|\))", decl):


### PR DESCRIPTION
_create_stub_handler() of tracer.py failed with unicode error when handling manual pages containing unicode characters (tested with openat on Ubuntu 12.04). This commit makes the function handle unicode errors gracefully by replacing problematic characters.