### PR TITLE
Add prototype names to repl autocomplete

### DIFF
--- a/src/frida/repl.py
+++ b/src/frida/repl.py
@@ -388,7 +388,8 @@ def main():
 
             try:
                 if encountered_dot:
-                    for key in self._repl._evaluate("Object.keys(" + before_dot + ")")[1]:
+                    for key in self._repl._evaluate("Object.keys(" + before_dot +
+                               ").concat(Object.getOwnPropertyNames(Object.getPrototypeOf(" + before_dot + ")))")[1]:
                         if key.startswith(after_dot):
                             yield Completion(key, -len(after_dot))
                 else:


### PR DESCRIPTION
For instance `NULL.<TAB>` would do nothing before, but it will now show `isNull`, `add`, `sub`, etc.