### PR TITLE
Improve compatibility between Python 2 and 3

### DIFF
--- a/src/frida/__init__.py
+++ b/src/frida/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
 
 import threading
 try:

--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
 
 import collections
 import errno

--- a/src/frida/core.py
+++ b/src/frida/core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
 
 import _frida
 import bisect

--- a/src/frida/discoverer.py
+++ b/src/frida/discoverer.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
 
 from frida.application import await_enter
 from frida.core import ModuleFunction

--- a/src/frida/ps.py
+++ b/src/frida/ps.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
+
 def main():
     from frida.application import ConsoleApplication
 

--- a/src/frida/repl.py
+++ b/src/frida/repl.py
@@ -1,4 +1,6 @@
-from __future__ import unicode_literals
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
+
 def main():
     import frida
     from frida.application import ConsoleApplication

--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
 
 import binascii
 import os


### PR DESCRIPTION
I also got rid of the executable bits on `application.py`.