### PR TITLE
FIX: localized process name is utf-8 encoding, and crash the ps.py.

### DIFF
--- a/src/frida/ps.py
+++ b/src/frida/ps.py
@@ -65,7 +65,7 @@ def main():
                 self._print("%s  %s" % (pid_column_width * "-", name_column_width * "-"))
                 line_format = "%" + str(pid_column_width) + "d  %s"
                 for process in sorted(processes, key=cmp_to_key(compare_processes)):
-                    self._print(line_format % (process.pid, process.name))
+                    self._print(line_format % (process.pid, process.name.decode('utf-8')))
             self._exit(0)
 
     def compare_applications(a, b):


### PR DESCRIPTION
Command: frida-ps -U
Result: crash
Reason: process name is utf-8 encoded.
File: src/frida/ps.py, line 68
Fix: process.name.decode('utf-8')
