### PR TITLE
Fix the manpage parser regexp

### DIFF
--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -1283,7 +1283,7 @@ class Repository(object):
                         man_argv.extend(["-E", "UTF-8"])
                     man_argv.extend(["-P", "col -b", "2", function.name])
                     output = subprocess.check_output(man_argv, stderr=devnull)
-                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}" + function.name + r"\(.*\n(^.+$\n)*)(?:.|\n)*^DESCRIPTION", output.decode('UTF-8', errors='replace'), re.MULTILINE)
+                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}\w+ " + function.name + r"\((?:.+\,\s*?$\n)*?(?:.+\;$\n))(?:.|\n)*^DESCRIPTION", output.decode('UTF-8', errors='replace'), re.MULTILINE)
                 if match:
                     decl = match.group(1)
                     for argm in re.finditer(r"([^* ]*)\s*(,|\))", decl):

--- a/src/frida/tracer.py
+++ b/src/frida/tracer.py
@@ -1283,7 +1283,7 @@ class Repository(object):
                         man_argv.extend(["-E", "UTF-8"])
                     man_argv.extend(["-P", "col -b", "2", function.name])
                     output = subprocess.check_output(man_argv, stderr=devnull)
-                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}\w+ " + function.name + r"\((?:.+\,\s*?$\n)*?(?:.+\;$\n))(?:.|\n)*^DESCRIPTION", output.decode('UTF-8', errors='replace'), re.MULTILINE)
+                match = re.search(r"^SYNOPSIS(?:.|\n)*?((?:^.+$\n)* {5}\w+ \**?" + function.name + r"\((?:.+\,\s*?$\n)*?(?:.+\;$\n))(?:.|\n)*^DESCRIPTION", output.decode('UTF-8', errors='replace'), re.MULTILINE)
                 if match:
                     decl = match.group(1)
                     for argm in re.finditer(r"([^* ]*)\s*(,|\))", decl):


### PR DESCRIPTION
Modify the manpage parser regexp to select only the first occurrence of the "TYPE FUNCTION(TYPE ARG, ...)", including multiline function prototypes.
https://github.com/frida/frida-python/issues/62

The proposed pull request should take the first match on a function prototype:

* if defined on one line, like `int open(const char *pathname, int flags);`
* if defined with varargs, like `int ioctl(int d, unsigned long request, ...);`
* if defined on multiple lines, like
```
      void *mmap(void *addr, size_t length, int prot, int flags,
              int fd, off_t offset);
```
* and also when the return type is a pointer of arbitrary depth, like `*mmap`