### PR TITLE
Fix Python 3 line endings/encoding regression

### DIFF
--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -253,12 +253,14 @@ class ConsoleApplication(object):
         encoded_args = []
         if sys.version_info[0] >= 3:
             string_type = str
+            decoder = "unicode-escape"
         else:
             string_type = unicode
+            decoder = "string-escape"
         encoding = sys.stdout.encoding or 'UTF-8'
         for arg in args:
             if isinstance(arg, string_type):
-                encoded_args.append(arg.encode(encoding, errors='replace'))
+                encoded_args.append(arg.encode(encoding, errors='replace').decode(decoder))
             else:
                 encoded_args.append(arg)
         print(*encoded_args, **kwargs)


### PR DESCRIPTION
Tested on Windows against Python 2.7.8 and 3.5.1 with cmd (cp-437).

Was previously printing out:
```
b"    _____\n   (_____)\n    |   |    Frida 6.0.4 - A world-class dynamic instrumentation framework\n    |   |
\n    |`-'|    Commands:\n    |   |        help      -> Displays the help system\n    |   |        object?   -
> Display information about 'object'\n    |   |        exit/quit -> Exit\n    |   |\n    |   |    More info at
 http://www.frida.re/docs/home/\n    `._.'\n"
```