### PR TITLE
Resolve pyconfig pain point in Windows build scenario

### DIFF
--- a/src/_frida.c
+++ b/src/_frida.c
@@ -14,6 +14,21 @@
 #ifdef _POSIX_C_SOURCE
 # undef _POSIX_C_SOURCE
 #endif
+
+/*
+ * Don't propogate _DEBUG state to pyconfig as it incorrectly attempts to load
+ * debug libraries that don't normally ship with Python (e.g. 2.x). Debuggers
+ * wishing to spelunk the Python core can override this workaround by defining
+ * _FRIDA_ENABLE_PYDEBUG.
+ */
+#if defined (_DEBUG) && !defined (_FRIDA_ENABLE_PYDEBUG)
+# undef _DEBUG
+# include <pyconfig.h>
+# define _DEBUG
+#else
+# include <pyconfig.h>
+#endif
+
 #include <Python.h>
 #include <structmember.h>
 #ifdef _MSC_VER


### PR DESCRIPTION
pyconfig.h authors believe it is helpful to pepper their header with pragma lib directives hinging on the generic _DEBUG identifier, forcing the linker to attempt linkage with libs that don't ship with Python 2.x. This change eliminates the need to build Python from scratch or edit the Python include.

This change can be overridden at compile time via _FRIDA_ENABLE_PYDEBUG.