### PR TITLE
Added ability to not-pause at startup

### DIFF
--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -88,6 +88,9 @@ class ConsoleApplication(object):
                 action='store_true', dest="enable_debugger", default=False)
             parser.add_option("--disable-jit", help="disable JIT",
                 action='store_true', dest="disable_jit", default=False)
+            parser.add_option("--nopause", help="automatically start main thread after startup",
+                action='store_true', dest="no_pause", default=False)
+
         self._add_options(parser)
 
         (options, args) = parser.parse_args()
@@ -100,6 +103,7 @@ class ConsoleApplication(object):
         self._device_type = options.device_type
         self._host = options.host
         self._device = None
+        self._no_pause = options.no_pause
         self._schedule_on_output = lambda pid, fd, data: self._reactor.schedule(lambda: self._on_output(pid, fd, data))
         self._schedule_on_device_lost = lambda: self._reactor.schedule(self._on_device_lost)
         self._spawned_pid = None

--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -88,7 +88,7 @@ class ConsoleApplication(object):
                 action='store_true', dest="enable_debugger", default=False)
             parser.add_option("--disable-jit", help="disable JIT",
                 action='store_true', dest="disable_jit", default=False)
-            parser.add_option("--nopause", help="automatically start main thread after startup",
+            parser.add_option("--no-pause", help="automatically start main thread after startup",
                 action='store_true', dest="no_pause", default=False)
 
         self._add_options(parser)

--- a/src/frida/repl.py
+++ b/src/frida/repl.py
@@ -63,7 +63,6 @@ def main():
                     self._update_status("Spawned `{command}`. Use %resume to let the main thread start executing!".format(command=" ".join(self._spawned_argv)))
             else:
                 self._clear_status()
-                
             self._ready.set()
 
         def _on_stop(self):

--- a/src/frida/repl.py
+++ b/src/frida/repl.py
@@ -59,7 +59,6 @@ def main():
                 if self._no_pause:
                     self._update_status("Spawned `{command}`. Resuming main thread!".format(command=" ".join(self._spawned_argv)))
                     self._do_magic("resume")
-
                 else:
                     self._update_status("Spawned `{command}`. Use %resume to let the main thread start executing!".format(command=" ".join(self._spawned_argv)))
             else:

--- a/src/frida/repl.py
+++ b/src/frida/repl.py
@@ -56,9 +56,15 @@ def main():
                 return
 
             if self._spawned_argv is not None:
-                self._update_status("Spawned `{command}`. Use %resume to let the main thread start executing!".format(command=" ".join(self._spawned_argv)))
+                if self._no_pause:
+                    self._update_status("Spawned `{command}`. Resuming main thread!".format(command=" ".join(self._spawned_argv)))
+                    self._do_magic("resume")
+
+                else:
+                    self._update_status("Spawned `{command}`. Use %resume to let the main thread start executing!".format(command=" ".join(self._spawned_argv)))
             else:
                 self._clear_status()
+                
             self._ready.set()
 
         def _on_stop(self):


### PR DESCRIPTION
Currently, the application waits for the user to start the application using %resume. This patch adds a --nopause argument that automatically calls %resume so that no further user interaction is required.