### PR TITLE
Using "UTF-8" as decoder for Darwin OS.

### DIFF
--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -292,6 +292,8 @@ class ConsoleApplication(object):
         if sys.version_info[0] >= 3:
             string_type = str
             decoder = "unicode-escape"
+            if platform.system() == 'Darwin':
+                decoder = "UTF-8"
         else:
             string_type = unicode
             decoder = "string-escape"


### PR DESCRIPTION
Using "UTF-8" as decoder for Darwin OS so that unicode characters get printed as is.

Because the process name which ``+[NSRunningApplication runningApplicationWithProcessIdentifier:]`` and ``SBSCopyLocalizedApplicationNameForDisplayIdentifier`` gives is not encoded in ``unicode-escape`` but ``UTF-8``.

For example, if there is a process named ``猫`` in Darwin OS (a.k.a iOS and macOS), frida-ps prints some meaningless characters like ``ç«`` due to mistakenly decoding UTF-8 string as unicode-escape string.

After appiled the patch, frida-ps prints ``猫`` as it supposed to be.

Signed-off-by: 0xBBC<0xbbc@0xbbc.com>