### PR TITLE
fix TypeError when reading console input on windows

### DIFF
--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -30,7 +30,7 @@ def input_with_timeout(timeout):
                 if ord(c) == 13: # enter_key
                     break
                 elif ord(c) >= 32: #space_char
-                    s += c
+                    s += c.decode('utf-8')
             if time() - start_time > timeout:
                 return None
 


### PR DESCRIPTION
This error occurs when pressing a key in the console window of a frida-trace session on Windows (Python 3.6)
```
gTraceback (most recent call last):
  File "C:\Program Files (x86)\Python36-32\Scripts\frida-trace-script.py", line 11, in <module>
    load_entry_point('frida==10.3.8', 'console_scripts', 'frida-trace')()
  File "c:\program files (x86)\python36-32\lib\site-packages\frida\tracer.py", line 866, in main
    app.run()
  File "c:\program files (x86)\python36-32\lib\site-packages\frida\application.py", line 163, in run
    self._reactor.run()
  File "c:\program files (x86)\python36-32\lib\site-packages\frida\application.py", line 388, in run
    self._run_until_return(self)
  File "c:\program files (x86)\python36-32\lib\site-packages\frida\tracer.py", line 818, in _await_ctrl_c
    input_with_timeout(0.5)
  File "c:\program files (x86)\python36-32\lib\site-packages\frida\application.py", line 33, in input_with_timeout
    s += c
TypeError: must be str, not bytes
```

This has not been tested on Python 2.7.