### PR TITLE
Bug fix: Handle unicode decoding errors with replacing

### DIFF
--- a/src/frida/application.py
+++ b/src/frida/application.py
@@ -323,7 +323,7 @@ class ConsoleApplication(object):
         encoding = sys.stdout.encoding or 'UTF-8'
         for arg in args:
             if isinstance(arg, string_type):
-                encoded_args.append(arg.encode(encoding, errors='replace').decode(decoder))
+                encoded_args.append(arg.encode(encoding, errors='replace').decode(decoder, errors='replace'))
             else:
                 encoded_args.append(arg)
         print(*encoded_args, **kwargs)


### PR DESCRIPTION
This fixes the following error:
```
Traceback (most recent call last):
  File "frida/core.py", line 394, in _on_message
    self._log_handler(level, text)
  File "frida/repl.py", line 74, in _log
    ConsoleApplication._log(self, level, text)
  File "frida/application.py", line 334, in _log
    self._print(text)
  File "frida/application.py", line 326, in _print
    encoded_args.append(arg.encode(encoding, errors='replace').decode(decoder)) # , errors='replace'
UnicodeDecodeError: 'unicodeescape' codec can't decode bytes in position 1249-1254: truncated \UXXXXXXXX escape
```