### PR TITLE
[Frida-Python][Terminal] Call raw_input from emacs shell

### DIFF
--- a/src/frida/repl.py
+++ b/src/frida/repl.py
@@ -174,7 +174,7 @@ def main():
                 if not reactor.is_running():
                     return
 
-            have_terminal = sys.stdin.isatty() and sys.stdout.isatty()
+            have_terminal = sys.stdin.isatty() and sys.stdout.isatty() and not os.environ.get("TERM", '') == "dumb"
 
             while True:
                 expression = ""
@@ -219,7 +219,7 @@ def main():
                                 finally:
                                     eventloop.close()
                             else:
-                                line = get_input()
+                                line = get_input(prompt)
                         except EOFError:
                             if have_terminal:
                                 self._print("\nThank you for using Frida!")


### PR DESCRIPTION
1. Make frida request input using raw_input when running in emacs shell.
2. The get_input requests one parameter, so give it to satisfy an angry python exception.
3. Im not sure if the "have_terminal" should be true only when the stdin is a file. If so, the os.environ.get("TERM", '') == "dumb" should be inside the "if have_terminal" if, with get_input instead using CommandLineInteface.