### PR TITLE
ambiguous name; default use first

### DIFF
--- a/src/frida/core.py
+++ b/src/frida/core.py
@@ -68,7 +68,8 @@ class Device(object):
         if len(matching) == 1:
             return matching[0]
         elif len(matching) > 1:
-            raise _frida.ProcessNotFoundError("ambiguous name; it matches: %s" % ", ".join(["%s (pid: %d)" % (process.name, process.pid) for process in matching]))
+            print("ambiguous name; default use first; it matches: %s" % ", ".join(["%s (pid: %d)" % (process.name, process.pid) for process in matching]))
+            return matching[0]
         else:
             raise _frida.ProcessNotFoundError("unable to find process with name '%s'" % process_name)
 


### PR DESCRIPTION
There are two same process name , maybe I do not care in many cases, so return the first process pid will be ok and give the notice about this is enough