### PR TITLE
Fixed module object name

### DIFF
--- a/src/frida/core.py
+++ b/src/frida/core.py
@@ -145,7 +145,7 @@ class Session(FunctionContainer):
     def enumerate_modules(self):
         if self._modules is None:
             raw_modules = self._get_api().enumerate_modules()
-            self._modules = [Module(data['name'], int(data['base'], 16), data['size'], data['path'], self) for data in raw_modules]
+            self._modules = [Module(data['name'], int(data['base_address'], 16), data['size'], data['path'], self) for data in raw_modules]
         return self._modules
 
     def prefetch_modules(self):


### PR DESCRIPTION
Updated base with base_address under enumerate_modules function.

On trying to print the base address with ``base``, getting an error saying ``AttributeError: Module object has no attribute base`` 
Switching it to ``base_address`` fixes the issue since the attribute name was probably mistyped. 