### PR TITLE
Show long description with Markdown on PyPI

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -137,6 +137,7 @@ setup(
     version=frida_version,
     description="Inject JavaScript to explore native apps on Windows, macOS, Linux, iOS, Android, and QNX",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Frida Developers",
     author_email="oleavr@nowsecure.com",
     url="https://www.frida.re",


### PR DESCRIPTION
https://pypi.org/project/frida/ doesn't render README.md as Markdown:

---

![image](https://user-images.githubusercontent.com/1324225/41202751-25f91b48-6cd6-11e8-900a-054bdddba162.png)

---

But the good news is now that the new PyPI (aka Warehouse) has been released, Markdown is supported.

More info and examples:

* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example
* https://pypi.org/project/markdown-description-example/