### PR TITLE
Declare explicit support for maintained Python versions

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -95,7 +95,7 @@ class FridaPrebuiltExt(build_ext):
 
                 if len(urls) == 0:
                     raise Exception("Could not find prebuilt Frida extension. "
-                                    "Prebuilds only provided for python 2.6-2.7 and 3.x.")
+                                    "Prebuilds only provided for Python 2.7 and 3.4+.")
 
                 url = urls[0]
                 egg_filename = url['filename']
@@ -161,7 +161,11 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: JavaScript",
         "Topic :: Software Development :: Debuggers",


### PR DESCRIPTION
Python 2.6 and 3.0-3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

They're also little used.

Here's the pip installs for Frida from PyPI for May 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  72.70% |          2,402 |
| 3.6            |  21.43% |            708 |
| 3.5            |   4.60% |            152 |
| 3.4            |   0.88% |             29 |
| 3.7            |   0.27% |              9 |
| 2.6            |   0.06% |              2 |
| 3.8            |   0.03% |              1 |
| None           |   0.03% |              1 |
| Total          |         |          3,304 |

Source:
`pypinfo --start-date 2018-05-01 --end-date 2018-05-31 --percent --markdown frida pyversion`