### PR TITLE
Refactor log handler access logic

### DIFF
--- a/frida/core.py
+++ b/frida/core.py
@@ -237,7 +237,7 @@ class Script(object):
         self._impl = impl
 
         self._on_message_callbacks = []
-        self._log_handler = self._on_log
+        self._log_handler = self.default_log_handler
 
         self._pending = {}
         self._next_request_id = 1
@@ -279,10 +279,10 @@ class Script(object):
             self._impl.off(signal, callback)
 
     def set_log_handler(self, handler):
-        if handler is not None:
-            self._log_handler = handler
-        else:
-            self._log_handler = self._on_log
+        self._log_handler = handler
+
+    def get_log_handler(self):
+        return self._log_handler
 
     @cancellable
     def _rpc_request(self, *args):
@@ -378,7 +378,7 @@ class Script(object):
                 except:
                     traceback.print_exc()
 
-    def _on_log(self, level, text):
+    def default_log_handler(self, level, text):
         if level == 'info':
             print(text, file=sys.stdout)
         else:

--- a/frida/core.py
+++ b/frida/core.py
@@ -284,6 +284,12 @@ class Script(object):
     def set_log_handler(self, handler):
         self._log_handler = handler
 
+    def default_log_handler(self, level, text):
+        if level == 'info':
+            print(text, file=sys.stdout)
+        else:
+            print(text, file=sys.stderr)
+
     @cancellable
     def _rpc_request(self, *args):
         result = [False, None, None]
@@ -377,12 +383,6 @@ class Script(object):
                     callback(message, data)
                 except:
                     traceback.print_exc()
-
-    def default_log_handler(self, level, text):
-        if level == 'info':
-            print(text, file=sys.stdout)
-        else:
-            print(text, file=sys.stderr)
 
 
 class RPCException(Exception):

--- a/frida/core.py
+++ b/frida/core.py
@@ -278,11 +278,11 @@ class Script(object):
         else:
             self._impl.off(signal, callback)
 
-    def set_log_handler(self, handler):
-        self._log_handler = handler
-
     def get_log_handler(self):
         return self._log_handler
+
+    def set_log_handler(self, handler):
+        self._log_handler = handler
 
     @cancellable
     def _rpc_request(self, *args):


### PR DESCRIPTION
- expose the default log handler
- remove the ability to reset the log handler by setting it to `None`
- add `get_log_handler()`