### PR TITLE
Expose system_parameters via python bindings

### DIFF
--- a/frida/__init__.py
+++ b/frida/__init__.py
@@ -74,6 +74,10 @@ def inject_library_blob(target, blob, entrypoint, data, **kwargs):
     return get_local_device().inject_library_blob(target, blob, entrypoint, data, **kwargs)
 
 
+def query_system_parameters(**kwargs):
+    return get_local_device().query_system_parameters(**kwargs)
+
+
 def get_local_device(**kwargs):
     return get_device_matching(lambda d: d.type == 'local', timeout=0, **kwargs)
 

--- a/frida/core.py
+++ b/frida/core.py
@@ -184,6 +184,10 @@ class Device(object):
         else:
             return self.get_process(target).pid
 
+    @cancellable
+    def query_system_parameters(self):
+        return self._impl.query_system_parameters()
+
 
 class Bus(object):
     def __init__(self, impl):

--- a/src/_frida.c
+++ b/src/_frida.c
@@ -3222,7 +3222,7 @@ PyDevice_query_system_parameters (PyDevice * self, PyObject * args)
   if (error != NULL)
     return PyFrida_raise (error);
 
-  return PyGObject_marshal_parameters_dict(system_parameters);
+  return PyGObject_marshal_parameters_dict (system_parameters);
 }
 
 

--- a/src/_frida.c
+++ b/src/_frida.c
@@ -531,7 +531,7 @@ static PyMethodDef PyDevice_methods[] =
   { "attach", (PyCFunction) PyDevice_attach, METH_VARARGS | METH_KEYWORDS, "Attach to a PID." },
   { "inject_library_file", (PyCFunction) PyDevice_inject_library_file, METH_VARARGS, "Inject a library file to a PID." },
   { "inject_library_blob", (PyCFunction) PyDevice_inject_library_blob, METH_VARARGS, "Inject a library blob to a PID." },
-  { "open_channel_hex", (PyCFunction) PyDevice_open_channel, METH_VARARGS, "Open a device-specific communication channel." },
+  { "open_channel", (PyCFunction) PyDevice_open_channel, METH_VARARGS, "Open a device-specific communication channel." },
   { "query_system_parameters", (PyCFunction) PyDevice_query_system_parameters, METH_NOARGS, "Returns a dictionary of information about the current host system." },
   { NULL }
 };

--- a/src/_frida.c
+++ b/src/_frida.c
@@ -3214,7 +3214,7 @@ static PyObject *
 PyDevice_query_system_parameters (PyDevice * self, PyObject * args)
 {
   GError * error = NULL;
-  GHashTable * system_parameters = frida_device_query_system_parameters_sync(PY_GOBJECT_HANDLE (self), g_cancellable_get_current (), &error);
+  GHashTable * system_parameters = frida_device_query_system_parameters_sync (PY_GOBJECT_HANDLE (self), g_cancellable_get_current (), &error);
 
   if (system_parameters == NULL)
     return PyDict_New ();

--- a/src/_frida.c
+++ b/src/_frida.c
@@ -359,6 +359,7 @@ static FridaSessionOptions * PyDevice_parse_session_options (const gchar * realm
 static PyObject * PyDevice_inject_library_file (PyDevice * self, PyObject * args);
 static PyObject * PyDevice_inject_library_blob (PyDevice * self, PyObject * args);
 static PyObject * PyDevice_open_channel (PyDevice * self, PyObject * args);
+static PyObject * PyDevice_query_system_parameters (PyDevice * self, PyObject * args);
 
 static PyObject * PyApplication_new_take_handle (FridaApplication * handle);
 static int PyApplication_init (PyApplication * self, PyObject * args, PyObject * kw);
@@ -530,7 +531,8 @@ static PyMethodDef PyDevice_methods[] =
   { "attach", (PyCFunction) PyDevice_attach, METH_VARARGS | METH_KEYWORDS, "Attach to a PID." },
   { "inject_library_file", (PyCFunction) PyDevice_inject_library_file, METH_VARARGS, "Inject a library file to a PID." },
   { "inject_library_blob", (PyCFunction) PyDevice_inject_library_blob, METH_VARARGS, "Inject a library blob to a PID." },
-  { "open_channel", (PyCFunction) PyDevice_open_channel, METH_VARARGS, "Open a device-specific communication channel." },
+  { "open_channel_hex", (PyCFunction) PyDevice_open_channel, METH_VARARGS, "Open a device-specific communication channel." },
+  { "query_system_parameters", (PyCFunction) PyDevice_query_system_parameters, METH_NOARGS, "Returns a dictionary of information about the current host system." },
   { NULL }
 };
 
@@ -3206,6 +3208,21 @@ PyDevice_open_channel (PyDevice * self, PyObject * args)
     return PyFrida_raise (error);
 
   return PyIOStream_new_take_handle (stream);
+}
+
+static PyObject *
+PyDevice_query_system_parameters (PyDevice * self, PyObject * args)
+{
+  GError * error = NULL;
+  GHashTable * system_parameters = frida_device_query_system_parameters_sync(PY_GOBJECT_HANDLE (self), g_cancellable_get_current (), &error);
+
+  if (system_parameters == NULL)
+    return PyDict_New ();
+
+  if (error != NULL)
+    return PyFrida_raise (error);
+
+  return PyGObject_marshal_parameters_dict(system_parameters);
 }
 
 


### PR DESCRIPTION
Depends on frida/frida-core/pull/373

NOTE: this PR is based on the `feature/portal` branch.

Once merged, this PR allows for the querying of the system parameters from a python context.
E.g.

```python
>>> import frida
>>> d = frida.get_local_device()
>>> d.query_system_parameters()
{'platform': 'macos'}
```
or:

```python
>>> import frida
>>> d = frida.get_usb_device()
>>> d.query_system_parameters()
{'platform': 'android'}
```