### PR TITLE
setup: Fix "TypeError: endswith first arg must be bytes or a tuple of bytes, not str"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ def get_index_url_from_pip(config_name):
     assert config_name in index_url_pip_configs
 
     return subprocess.check_output([sys.executable, "-m", "pip", "config", "get", config_name],
-                                   stderr=subprocess.PIPE)
+                                   stderr=subprocess.PIPE, encoding="utf-8")
 
 
 def normalize_url(url):


### PR DESCRIPTION
`get_index_url_from_pip` returns bytes but `normalize_url` needs str