### PR TITLE
fix: deallocating None

### DIFF
--- a/src/_frida.c
+++ b/src/_frida.c
@@ -5568,7 +5568,8 @@ PyFrida_get_max_argument_count (PyObject * callable)
 
 beach:
   Py_XDECREF (args);
-  Py_XDECREF (varargs);
+  if (varargs != Py_None)
+    Py_XDECREF (varargs);
   Py_XDECREF (spec);
 
   return result;


### PR DESCRIPTION

```
Fatal Python error: deallocating None
...
Aborted
```

reproduce by command (may be no one use like that :)
```bash
python3  -c "import frida; dm = frida.get_device_manager(); list([dm.add_remote_device('127.0.0.1') for i in range(99999)])"
```
