### PR TITLE
on_message need carry script Object to reply frida in on_message callback

### DIFF
--- a/frida/core.py
+++ b/frida/core.py
@@ -552,7 +552,7 @@ class Script:
         else:
             for callback in self._on_message_callbacks[:]:
                 try:
-                    callback(message, data)
+                    callback(self, message, data)
                 except:
                     traceback.print_exc()
 


### PR DESCRIPTION
I think on_message needs to carry the Script object that generates the message (multiple process hooks will generate multiple script objects), so that the post method can be called in the callback to reply to frida.