### PR TITLE
Use ParamSpec for better type hints on `cancellable` decorator.

### DIFF
--- a/frida/core.py
+++ b/frida/core.py
@@ -38,6 +38,11 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import NotRequired
 
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
 from . import _frida
 
 _device_manager = None
@@ -73,11 +78,11 @@ def _filter_missing_kwargs(d: MutableMapping[Any, Any]) -> None:
 
 
 R = TypeVar("R")
+P = ParamSpec("P")
 
-
-def cancellable(f: Callable[..., R]) -> Callable[..., R]:
+def cancellable(f: Callable[P, R]) -> Callable[P, R]:
     @functools.wraps(f)
-    def wrapper(*args: Any, **kwargs: Any) -> R:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         cancellable = kwargs.pop("cancellable", None)
         if cancellable is not None:
             with cancellable:


### PR DESCRIPTION
As of Python 3.10 a new way to annotate decorators was [added](https://peps.python.org/pep-0612/#motivation).
Since `typing_extensions` now supports it, it can be a nice boost to local productivity with various IDEs.

Before:
![image](https://github.com/user-attachments/assets/d66085af-4557-4659-85b3-2aa80a832aa6)

After:
![image](https://github.com/user-attachments/assets/006c6b95-47d0-4edd-8a78-bcae1ff232ff)
