### PR TITLE
frida-python: use system Python dependency to fix pyconfig.h pathing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ if ndebug == 'true' or (ndebug == 'if-release' and not get_option('debug'))
   ]
 endif
 
-python_dep = python.dependency()
+python_dep = python.dependency(method: 'system')
 frida_core_dep = dependency('frida-core-1.0', default_options: [
   'frida_version=' + meson.project_version().replace('.dev', '-dev.'),
 ])


### PR DESCRIPTION
## Summary
- switch Python dependency discovery from default/auto to `method: 'system'`
- avoid include path mangling observed when using bundled pkg-config in this environment

## Problem
`frida-python` build failed while compiling `_frida` with:

```
fatal error: pyconfig.h: No such file or directory
```

The selected pkg-config path produced invalid include flags (`/usr/lib/include/...`).

## Fix
Use `python.dependency(method: 'system')` so Meson derives include/link information from the system Python installation instead of pkg-config.

## Validation
- `./configure` succeeds with `frida_python` enabled
- `make` succeeds end-to-end
- `_frida` extension compiles and links:
  - `[348/349] ... extension.c.o`
  - `[349/349] ... _frida.abi3.so`
